### PR TITLE
Update Exa tools to current API conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Exa is an AI-powered search tool that enables semantic search and content retrie
 
 The search endpoint lets you intelligently search the web and extract contents from the results.
 
-By default, it automatically chooses between traditional keyword search and Exa's embeddings-based model to find the most relevant results for your query.
-
 #### Parameters:
 
 - **query** (string, required): The search query to find relevant information on the web.

--- a/README.md
+++ b/README.md
@@ -26,19 +26,20 @@ By default, it automatically chooses between traditional keyword search and Exa'
 #### Parameters:
 
 - **query** (string, required): The search query to find relevant information on the web.
-- **search_type** (select, optional, default: "neural"): 
-  - Options: "neural" (semantic), "keyword" (traditional), "auto"
-  - Neural uses advanced AI for semantic understanding, keyword uses traditional search techniques
+- **search_type** (select, optional, default: "auto"): 
+  - Options: "auto", "fast", "instant", "deep"
+  - Auto is recommended for most queries
 - **num_results** (number, optional, default: 10): Maximum number of search results (1-100)
 - **include_domains** (string, optional): Comma-separated list of domains to include in results
 - **exclude_domains** (string, optional): Comma-separated list of domains to exclude from results
 - **start_published_date** (string, optional): Only include results published after this date (YYYY-MM-DD)
 - **end_published_date** (string, optional): Only include results published before this date (YYYY-MM-DD)
-- **use_autoprompt** (boolean, optional, default: true): Whether to use Exa's prompt engineering to improve the query
-- **text_contents** (boolean, optional, default: false): Whether to include text contents from each result
-- **highlight_results** (boolean, optional, default: false): Whether to highlight relevant snippets
+- **max_age_hours** (number, optional): Freshness control. 0 = always crawl, -1 = cache only, 24 = cache if less than 24h old
+- **include_highlights** (boolean, optional, default: true): Return query-relevant excerpts from each result
+- **highlights_max_characters** (number, optional): Maximum characters per highlight excerpt
+- **include_text** (boolean, optional, default: false): Return full page text (opt-in)
 - **category** (select, optional): Focus on specific data categories
-  - Options: "company", "research paper", "news", "pdf", "github", "tweet", "personal site", "linkedin profile", "financial report"
+  - Options: "company", "people", "research paper", "news", "personal site", "financial report"
 - **includeText** (string, optional): Text that must be present in results (up to 5 words)
 - **excludeText** (string, optional): Text that must not be present in results (up to 5 words)
 
@@ -77,11 +78,10 @@ Returns instant results from Exa's cache, with automatic live crawling as fallba
 #### Parameters:
 
 - **urls** (string, required): Comma-separated list of URLs to extract content from
-- **livecrawl** (select, optional, default: "never"):
-  - Options: "never", "fallback", "always", "auto"
-  - Choose the live crawling strategy for content retrieval
-- **full_page_text** (boolean, optional, default: false): Include the full text of each webpage, including subpages
-- **ai_page_summary** (boolean, optional, default: false): Generate a summary for each webpage using LLM
+- **max_age_hours** (number, optional): Freshness control. 0 = always crawl, -1 = cache only, 24 = cache if less than 24h old
+- **include_highlights** (boolean, optional, default: true): Return query-relevant excerpts from each page
+- **highlights_max_characters** (number, optional): Maximum characters per highlight excerpt
+- **full_page_text** (boolean, optional, default: false): Return full page text (opt-in)
 - **number_of_subpages** (number, optional, default: 1): Number of subpages to include in content extraction
 - **return_links** (number, optional, default: 1): Number of links to return from each webpage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The search endpoint lets you intelligently search the web and extract contents f
 
 - **query** (string, required): The search query to find relevant information on the web.
 - **search_type** (select, optional, default: "auto"): 
-  - Options: "auto", "fast", "instant", "deep"
+  - Options: "auto", "fast", "deep"
   - Auto is recommended for most queries
 - **num_results** (number, optional, default: 10): Maximum number of search results (1-100)
 - **include_domains** (string, optional): Comma-separated list of domains to include in results
@@ -45,7 +45,7 @@ The search endpoint lets you intelligently search the web and extract contents f
 
 Get the full page contents, summaries, and metadata for a list of URLs.
 
-Returns instant results from Exa's cache, with automatic live crawling as fallback for uncached pages.
+Returns results from Exa's cache, with automatic live crawling as fallback for uncached pages.
 
 #### Parameters:
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Description
 
-Exa is an AI-powered search tool that enables semantic search, content retrieval, similarity search, and answers generation using Exa's advanced API.
+Exa is an AI-powered search tool that enables semantic search and content retrieval using Exa's advanced API.
 
 ![Exa Logo](./_assets/image.png)
 
@@ -43,33 +43,7 @@ By default, it automatically chooses between traditional keyword search and Exa'
 - **includeText** (string, optional): Text that must be present in results (up to 5 words)
 - **excludeText** (string, optional): Text that must not be present in results (up to 5 words)
 
-### 2. Exa Answer (`exa_answer`)
-
-Get an LLM answer to a question informed by Exa search results. Fully compatible with OpenAI's chat completions endpoint.
-
-/answer performs an Exa search and uses an LLM (GPT-4o-mini) to generate either:
-- A direct answer for specific queries (i.e., "What is the capital of France?" would return "Paris")
-- A detailed summary with citations for open-ended queries (i.e., "What is the state of AI in healthcare?" would return a summary with citations to relevant sources)
-
-#### Parameters:
-
-- **query** (string, required): The question to be answered with supporting evidence from the web
-- **text** (boolean, optional, default: false): Include the full text content of each source in the results
-- **model** (select, optional, default: "exa"):
-  - Options: "exa", "exa-pro"
-  - Specify which model should process the query and generate the answer
-
-### 3. Exa Similar Links (`exa_similar`)
-
-Find similar links to the link provided and optionally return the contents of the pages.
-
-#### Parameters:
-
-- **url** (string, required): The source URL to find similar content for
-- **num_results** (number, optional, default: 10): Number of similar links to return (max 100)
-- **text** (boolean, optional, default: false): Include the full text content of each similar page
-
-### 4. Exa URL Contents (`exa_contents`)
+### 2. Exa URL Contents (`exa_contents`)
 
 Get the full page contents, summaries, and metadata for a list of URLs.
 

--- a/tools/exa_anwser.py
+++ b/tools/exa_anwser.py
@@ -46,12 +46,9 @@ class ExaAnswerTool(Tool):
             # Make API request using Authorization Bearer format
             headers = {
                 "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "x-exa-integration": "dify-community-integration",
             }
-            
-            # Print request details for debugging
-            print(f"Request URL: https://api.exa.ai/answer")
-            print(f"Request Payload: {json.dumps(payload)}")
             
             response = requests.post(
                 "https://api.exa.ai/answer",

--- a/tools/exa_contents.py
+++ b/tools/exa_contents.py
@@ -25,21 +25,7 @@ class ExaContentsTool(Tool):
         return instance
     
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
-        """
-        Execute a request to get content from URLs using the Exa API.
-        
-        Args:
-            tool_parameters: Dictionary containing:
-                - urls: List of URLs to fetch content from (required)
-                - livecrawl: Live crawling strategy (never/fallback/always/auto)
-                - full_page_text: Whether to include full webpage text
-                - ai_page_summary: Whether to include AI-generated summary
-                - number_of_subpages: Number of subpages to include
-                - return_links: Number of links to return
-        
-        Returns:
-            Generator yielding ToolInvokeMessage with content results
-        """
+        """Execute a request to get content from URLs using the Exa API."""
         try:
             # Get API key from runtime credentials
             api_key = self.runtime.credentials["exa_api_key"]

--- a/tools/exa_contents.py
+++ b/tools/exa_contents.py
@@ -88,37 +88,47 @@ class ExaContentsTool(Tool):
             print(f"Processed URLs: {urls}")
             
             # Get optional parameters
-            livecrawl_strategy = tool_parameters.get("livecrawl", "auto")  # Default to auto for better results
+            include_highlights = tool_parameters.get("include_highlights", True)
+            highlights_max_characters = tool_parameters.get("highlights_max_characters", None)
             full_page_text = tool_parameters.get("full_page_text", False)
-            ai_page_summary = tool_parameters.get("ai_page_summary", False)
+            max_age_hours = tool_parameters.get("max_age_hours", None)
             number_of_subpages = int(tool_parameters.get("number_of_subpages", 1))
             return_links = int(tool_parameters.get("return_links", 1))
-            
-            # Prepare API request - modify to match exa_search.py header format
+
+            # Backwards compat: map legacy livecrawl → maxAgeHours
+            livecrawl_compat = {
+                "always": 0, "never": -1, "fallback": 24, "auto": 24,
+            }
+            livecrawl = tool_parameters.get("livecrawl", None)
+            if max_age_hours is None and livecrawl:
+                max_age_hours = livecrawl_compat.get(livecrawl)
+
             headers = {
                 "x-api-key": api_key,
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "x-exa-integration": "dify-community-integration",
             }
-            
-            # New request format
-            payload = {
-                "ids": urls,  # Use ids field instead of urls, ensure it's in list format
-                "livecrawl": livecrawl_strategy
+
+            payload: dict[str, Any] = {
+                "ids": urls,
             }
-            
-            # Print debug information
-            print(f"Request payload: {json.dumps(payload)}")
-            
-            # Add conditional parameters
+
+            if max_age_hours is not None:
+                payload["maxAgeHours"] = max_age_hours
+
+            # Highlights default, text opt-in
+            if include_highlights:
+                if highlights_max_characters:
+                    payload["highlights"] = {"maxCharacters": int(highlights_max_characters)}
+                else:
+                    payload["highlights"] = True
+
             if full_page_text:
                 payload["text"] = True
-                
-            if ai_page_summary:
-                payload["summary"] = True
-                
+
             if number_of_subpages > 0:
                 payload["subpages"] = number_of_subpages
-                
+
             if return_links > 0:
                 payload["extras"] = {"links": return_links}
             

--- a/tools/exa_contents.yaml
+++ b/tools/exa_contents.yaml
@@ -30,46 +30,53 @@ parameters:
     llm_description: A list of URLs to extract content from, separated by commas.
     form: llm
 
-  - name: livecrawl
-    type: select
+  - name: max_age_hours
+    type: number
     required: false
-    default: 'never'
     label:
-      en_US: Live Crawling
-      zh_Hans: 实时爬取
-      pt_BR: Crawl em Tempo Real
-      ja_JP: リアルタイムクロール
+      en_US: Max Age (Hours)
+      zh_Hans: 最大缓存时间（小时）
+      pt_BR: Idade Máxima (Horas)
+      ja_JP: 最大キャッシュ時間（時間）
     human_description:
-      en_US: Specify the live crawling behavior.
-      zh_Hans: 指定实时爬取行为。
-      pt_BR: Especifique o comportamento de crawl em tempo real.
-      ja_JP: 実時間のクロールの動作を指定します。
-    llm_description: Choose the live crawling strategy for content retrieval.
-    options:
-      - label:
-          en_US: Never
-          zh_Hans: 从不
-          pt_BR: Nunca
-          ja_JP: なし
-        value: 'never'
-      - label:
-          en_US: Fallback
-          zh_Hans: 回退
-          pt_BR: Redundância
-          ja_JP: フォールバック
-        value: 'fallback'
-      - label:
-          en_US: Always
-          zh_Hans: 总是
-          pt_BR: Sempre
-          ja_JP: いつも
-        value: 'always'
-      - label:
-          en_US: Auto
-          zh_Hans: 自动
-          pt_BR: Auto
-          ja_JP: 自動
-        value: 'auto'
+      en_US: Freshness control. 0 = always crawl, -1 = cache only, 24 = cache if less than 24h old.
+      zh_Hans: 新鲜度控制。0 = 总是爬取，-1 = 仅缓存，24 = 如果缓存不到24小时则使用缓存。
+      pt_BR: Controle de frescor. 0 = sempre rastrear, -1 = apenas cache, 24 = cache se menos de 24h.
+      ja_JP: 鮮度制御。0 = 常にクロール、-1 = キャッシュのみ、24 = 24時間以内ならキャッシュ使用。
+    llm_description: Controls content freshness. 0 = always crawl, -1 = cache only, positive number = cache if younger than N hours.
+    form: form
+
+  - name: include_highlights
+    type: boolean
+    required: false
+    default: true
+    label:
+      en_US: Include Highlights
+      zh_Hans: 包含高亮摘要
+      pt_BR: Incluir Destaques
+      ja_JP: ハイライトを含める
+    human_description:
+      en_US: Return query-relevant excerpts from each page. Recommended for most use cases.
+      zh_Hans: 返回每个页面中与查询相关的摘要。适用于大多数场景。
+      pt_BR: Retorna trechos relevantes de cada página. Recomendado para a maioria dos casos.
+      ja_JP: 各ページからクエリに関連する抜粋を返します。ほとんどのケースで推奨。
+    llm_description: Return query-relevant excerpts from each page.
+    form: form
+
+  - name: highlights_max_characters
+    type: number
+    required: false
+    label:
+      en_US: Highlights Max Characters
+      zh_Hans: 高亮最大字符数
+      pt_BR: Máx. Caracteres de Destaques
+      ja_JP: ハイライト最大文字数
+    human_description:
+      en_US: Maximum number of characters per highlight excerpt.
+      zh_Hans: 每段高亮摘要的最大字符数。
+      pt_BR: Número máximo de caracteres por trecho destacado.
+      ja_JP: ハイライト抜粋ごとの最大文字数。
+    llm_description: Maximum number of characters per highlight excerpt.
     form: form
 
   - name: full_page_text
@@ -82,28 +89,11 @@ parameters:
       pt_BR: Texto Completo da Página
       ja_JP: 完全ページテキスト
     human_description:
-      en_US: Return full webpage text for every result, including for subpages.
-      zh_Hans: 返回每个结果的完整网页文本，包括子页面。
-      pt_BR: Retorna o texto completo da página web para cada resultado, incluindo para subpáginas.
-      ja_JP: 各結果の完全なウェブページテキストを返し、サブページも含む。
-    llm_description: Include the full text of each webpage, including subpages.
-    form: form
-
-  - name: ai_page_summary
-    type: boolean
-    required: false
-    default: false
-    label:
-      en_US: AI Page Summary
-      zh_Hans: AI页面摘要
-      pt_BR: Resumo AI da Página
-      ja_JP: AIページ要約
-    human_description:
-      en_US: Return an LLM-generated summary of each webpage.
-      zh_Hans: 返回每个网页的LLM生成的摘要。
-      pt_BR: Retorna um resumo gerado pelo LLM de cada página web.
-      ja_JP: 各ウェブページのLLM生成の要約を返します。
-    llm_description: Generate a summary for each webpage using LLM.
+      en_US: Return full webpage text. Opt-in; uses more tokens.
+      zh_Hans: 返回完整网页文本。选择启用；使用更多 token。
+      pt_BR: Retorna o texto completo da página. Opt-in; usa mais tokens.
+      ja_JP: 完全なウェブページテキストを返します。オプトイン；トークンをより多く使用。
+    llm_description: Return the full page text. Opt-in and uses more tokens than highlights.
     form: form
 
   - name: number_of_subpages

--- a/tools/exa_search.py
+++ b/tools/exa_search.py
@@ -9,29 +9,22 @@ from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
 
 class ExaSearchTool(Tool):
+    # Backwards-compat mapping: livecrawl → maxAgeHours
+    _LIVECRAWL_TO_MAX_AGE = {
+        "always": 0,
+        "never": -1,
+        "fallback": 24,
+        "preferred": 0,
+        "auto": 24,
+    }
+
+    # Backwards-compat mapping: old search types → new
+    _SEARCH_TYPE_COMPAT = {
+        "neural": "auto",
+        "keyword": "auto",
+    }
+
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
-        """
-        Execute a search using the Exa Search API.
-        
-        Args:
-            tool_parameters: Dictionary containing:
-                - query: The search query string (required)
-                - search_type: "neural", "keyword", or "auto" (default: neural)
-                - num_results: Maximum number of results to return (default: 10)
-                - include_domains: Comma-separated list of domains to include
-                - exclude_domains: Comma-separated list of domains to exclude
-                - start_published_date: Start date for filtering results (YYYY-MM-DD)
-                - end_published_date: End date for filtering results (YYYY-MM-DD)
-                - use_autoprompt: Whether to use Exa's query enhancement (default: True)
-                - text_contents: Whether to include full text of results (default: False)
-                - highlight_results: Whether to highlight relevant snippets (default: False)
-                - category: Filter results by category
-                - includeText: Text that must be present in results
-                - excludeText: Text that must not be present in results
-        
-        Returns:
-            Generator yielding ToolInvokeMessage with search results (both JSON and text formats)
-        """
         try:
             # Get API key from runtime credentials
             api_key = self.runtime.credentials["exa_api_key"]
@@ -42,18 +35,30 @@ class ExaSearchTool(Tool):
                 raise ValueError("Search query is required")
                 
             # Optional parameters with defaults
-            search_type = tool_parameters.get("search_type", "neural")
+            search_type = tool_parameters.get("search_type", "auto")
+            # Backwards compat: map old search types
+            search_type = self._SEARCH_TYPE_COMPAT.get(search_type, search_type)
+
             num_results = int(tool_parameters.get("num_results", 10))
             include_domains = tool_parameters.get("include_domains", "")
             exclude_domains = tool_parameters.get("exclude_domains", "")
             start_published_date = tool_parameters.get("start_published_date", "")
             end_published_date = tool_parameters.get("end_published_date", "")
-            use_autoprompt = tool_parameters.get("use_autoprompt", True)
-            text_contents = tool_parameters.get("text_contents", True)
-            highlight_results = tool_parameters.get("highlight_results", False)
+            include_highlights = tool_parameters.get("include_highlights", True)
+            highlights_max_characters = tool_parameters.get("highlights_max_characters", None)
+            include_full_text = tool_parameters.get("include_text", False)
+            max_age_hours = tool_parameters.get("max_age_hours", None)
             category = tool_parameters.get("category", None)
-            include_text = tool_parameters.get("includeText", None)
-            exclude_text = tool_parameters.get("excludeText", None)
+            include_text_filter = tool_parameters.get("includeText", None)
+            exclude_text_filter = tool_parameters.get("excludeText", None)
+
+            # Backwards compat: map legacy use_autoprompt
+            use_autoprompt = tool_parameters.get("use_autoprompt", None)
+
+            # Backwards compat: map legacy livecrawl → maxAgeHours
+            livecrawl = tool_parameters.get("livecrawl", None)
+            if max_age_hours is None and livecrawl:
+                max_age_hours = self._LIVECRAWL_TO_MAX_AGE.get(livecrawl)
             
             # Process domain lists
             include_domains_list = [d.strip() for d in include_domains.split(",")] if include_domains else []
@@ -63,37 +68,44 @@ class ExaSearchTool(Tool):
             payload: Dict[str, Any] = {
                 "query": query,
                 "numResults": num_results,
-                "useAutoprompt": use_autoprompt,
                 "type": search_type if search_type != "auto" else None,
                 "includeDomains": include_domains_list if include_domains_list else None,
                 "excludeDomains": exclude_domains_list if exclude_domains_list else None,
                 "startPublishedDate": start_published_date if start_published_date else None,
                 "endPublishedDate": end_published_date if end_published_date else None,
                 "category": category,
-                "includeText": [include_text] if include_text else None,
-                "excludeText": [exclude_text] if exclude_text else None
+                "includeText": [include_text_filter] if include_text_filter else None,
+                "excludeText": [exclude_text_filter] if exclude_text_filter else None,
             }
-            
+
+            if use_autoprompt is not None:
+                payload["useAutoprompt"] = use_autoprompt
+
+            if max_age_hours is not None:
+                payload["maxAgeHours"] = max_age_hours
+
             # Remove None values from payload
             payload = {k: v for k, v in payload.items() if v is not None}
-            
-            # Add contents options if needed
-            contents_options = {}
-            if text_contents:
+
+            # Build contents options — highlights default, text opt-in
+            contents_options: Dict[str, Any] = {}
+            if include_highlights:
+                if highlights_max_characters:
+                    contents_options["highlights"] = {"maxCharacters": int(highlights_max_characters)}
+                else:
+                    contents_options["highlights"] = True
+            if include_full_text:
                 contents_options["text"] = True
-            if highlight_results:
-                contents_options["highlights"] = True
-            
+
             if contents_options:
                 payload["contents"] = contents_options
             
             # Make API request
             headers = {
                 "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "x-exa-integration": "dify-community-integration",
             }
-            print("Payload being sent to Exa API:")
-            print(json.dumps(payload, indent=2))
             response = requests.post(
                 "https://api.exa.ai/search",
                 json=payload,

--- a/tools/exa_search.yaml
+++ b/tools/exa_search.yaml
@@ -72,12 +72,6 @@ parameters:
           ja_JP: 高速
         value: fast
       - label:
-          en_US: Instant
-          zh_Hans: 即时
-          pt_BR: Instantâneo
-          ja_JP: インスタント
-        value: instant
-      - label:
           en_US: Deep
           zh_Hans: 深度
           pt_BR: Profundo

--- a/tools/exa_search.yaml
+++ b/tools/exa_search.yaml
@@ -46,37 +46,43 @@ parameters:
   - name: search_type
     type: select
     required: false
-    default: neural
+    default: auto
     label:
       en_US: Search Type
       zh_Hans: 搜索类型
       pt_BR: Tipo de pesquisa
       ja_JP: 検索タイプ
     human_description:
-      en_US: The type of search to perform - neural (semantic), keyword (traditional), or auto.
-      zh_Hans: 要执行的搜索类型 - 神经（语义），关键词（传统），或自动。
-      pt_BR: O tipo de pesquisa a ser realizada - neural (semântica), por palavra-chave (tradicional), ou auto.
-      ja_JP: 実行する検索のタイプ - ニューラル（意味的），キーワード（従来型），または自動。
-    llm_description: The type of search to perform - neural uses advanced AI for semantic understanding, keyword uses traditional search techniques, and auto dynamically selects the best approach.
+      en_US: The type of search to perform. Auto is recommended for most queries.
+      zh_Hans: 要执行的搜索类型。自动适用于大多数查询。
+      pt_BR: O tipo de pesquisa a ser realizada. Auto é recomendado para a maioria das consultas.
+      ja_JP: 実行する検索のタイプ。ほとんどのクエリには自動が推奨されます。
+    llm_description: The type of search to perform. Auto is recommended for most queries.
     options:
-      - label:
-          en_US: Neural
-          zh_Hans: 神经
-          pt_BR: Neural
-          ja_JP: ニューラル
-        value: neural
-      - label:
-          en_US: Keyword
-          zh_Hans: 关键词
-          pt_BR: Palavra-chave
-          ja_JP: キーワード
-        value: keyword
       - label:
           en_US: Auto
           zh_Hans: 自动
           pt_BR: Auto
           ja_JP: 自動
         value: auto
+      - label:
+          en_US: Fast
+          zh_Hans: 快速
+          pt_BR: Rápido
+          ja_JP: 高速
+        value: fast
+      - label:
+          en_US: Instant
+          zh_Hans: 即时
+          pt_BR: Instantâneo
+          ja_JP: インスタント
+        value: instant
+      - label:
+          en_US: Deep
+          zh_Hans: 深度
+          pt_BR: Profundo
+          ja_JP: ディープ
+        value: deep
     form: form
   - name: num_results
     type: number
@@ -156,53 +162,67 @@ parameters:
       ja_JP: この日付以前に公開された結果のみを含める（YYYY-MM-DD形式）。
     llm_description: Only include results published before this date in YYYY-MM-DD format.
     form: llm
-  - name: use_autoprompt
+  - name: max_age_hours
+    type: number
+    required: false
+    label:
+      en_US: Max Age (Hours)
+      zh_Hans: 最大缓存时间（小时）
+      pt_BR: Idade Máxima (Horas)
+      ja_JP: 最大キャッシュ時間（時間）
+    human_description:
+      en_US: Freshness control. 0 = always crawl, -1 = cache only, 24 = cache if less than 24h old.
+      zh_Hans: 新鲜度控制。0 = 总是爬取，-1 = 仅缓存，24 = 如果缓存不到24小时则使用缓存。
+      pt_BR: Controle de frescor. 0 = sempre rastrear, -1 = apenas cache, 24 = cache se menos de 24h.
+      ja_JP: 鮮度制御。0 = 常にクロール、-1 = キャッシュのみ、24 = 24時間以内ならキャッシュ使用。
+    llm_description: Controls content freshness. 0 = always crawl, -1 = cache only, positive number = cache if younger than N hours.
+    form: form
+  - name: include_highlights
     type: boolean
     required: false
     default: true
     label:
-      en_US: Use Autoprompt
-      zh_Hans: 使用自动提示
-      pt_BR: Usar Autoprompt
-      ja_JP: 自動プロンプトを使用
+      en_US: Include Highlights
+      zh_Hans: 包含高亮摘要
+      pt_BR: Incluir Destaques
+      ja_JP: ハイライトを含める
     human_description:
-      en_US: Whether to use Exa's prompt engineering to improve the query.
-      zh_Hans: 是否使用 Exa 的提示工程来改进查询。
-      pt_BR: Se deve usar a engenharia de prompt da Exa para melhorar a consulta.
-      ja_JP: Exaのプロンプトエンジニングを使用してクエリを改善するかどうか。
-    llm_description: Whether to use Exa's prompt engineering to improve the query. When true, Exa will automatically rewrite the query to improve search results.
+      en_US: Return query-relevant excerpts from each result. Recommended for most use cases.
+      zh_Hans: 返回每个结果中与查询相关的摘要。适用于大多数场景。
+      pt_BR: Retorna trechos relevantes de cada resultado. Recomendado para a maioria dos casos.
+      ja_JP: 各結果からクエリに関連する抜粋を返します。ほとんどのケースで推奨。
+    llm_description: Return query-relevant excerpts from each result. Uses fewer tokens than full text and is recommended for most use cases.
     form: form
-  - name: text_contents
+  - name: highlights_max_characters
+    type: number
+    required: false
+    label:
+      en_US: Highlights Max Characters
+      zh_Hans: 高亮最大字符数
+      pt_BR: Máx. Caracteres de Destaques
+      ja_JP: ハイライト最大文字数
+    human_description:
+      en_US: Maximum number of characters per highlight excerpt.
+      zh_Hans: 每段高亮摘要的最大字符数。
+      pt_BR: Número máximo de caracteres por trecho destacado.
+      ja_JP: ハイライト抜粋ごとの最大文字数。
+    llm_description: Maximum number of characters per highlight excerpt.
+    form: form
+  - name: include_text
     type: boolean
     required: false
     default: false
     label:
-      en_US: Include Text Contents
-      zh_Hans: 包含文本内容
-      pt_BR: Incluir conteúdo de texto
-      ja_JP: テキスト内容を含める
+      en_US: Include Full Text
+      zh_Hans: 包含全文
+      pt_BR: Incluir Texto Completo
+      ja_JP: 全文を含める
     human_description:
-      en_US: Whether to include the text contents from each search result.
-      zh_Hans: 是否包含每个搜索结果的文本内容。
-      pt_BR: Se deve incluir o conteúdo de texto de cada resultado da pesquisa.
-      ja_JP: 各検索結果からテキスト内容を含めるかどうか。
-    llm_description: Whether to include the text contents from each search result. When true, the response will include the text content of each webpage.
-    form: form
-  - name: highlight_results
-    type: boolean
-    required: false
-    default: false
-    label:
-      en_US: Highlight Results
-      zh_Hans: 高亮结果
-      pt_BR: Destacar resultados
-      ja_JP: 結果をハイライト
-    human_description:
-      en_US: Whether to highlight relevant text snippets in the search results.
-      zh_Hans: 是否在搜索结果中高亮显示相关文本片段。
-      pt_BR: Se deve destacar trechos de texto relevantes nos resultados da pesquisa.
-      ja_JP: 検索結果内の関連テキスト部分をハイライトするかどうか。
-    llm_description: Whether to highlight relevant text snippets in the search results. When true, relevant sections of text will be highlighted.
+      en_US: Return the full page text for each result. Opt-in; uses more tokens.
+      zh_Hans: 返回每个结果的完整页面文本。选择启用；使用更多 token。
+      pt_BR: Retorna o texto completo da página para cada resultado. Opt-in; usa mais tokens.
+      ja_JP: 各結果の完全なページテキストを返します。オプトイン；より多くのトークンを使用。
+    llm_description: Return the full page text for each result. Opt-in and uses more tokens than highlights.
     form: form
   - name: category
     type: select
@@ -226,6 +246,12 @@ parameters:
           ja_JP: 会社
         value: company
       - label:
+          en_US: People
+          zh_Hans: 人物
+          pt_BR: Pessoas
+          ja_JP: 人物
+        value: people
+      - label:
           en_US: Research Paper
           zh_Hans: 研究论文
           pt_BR: Artigo de Pesquisa
@@ -238,35 +264,11 @@ parameters:
           ja_JP: ニュース
         value: news
       - label:
-          en_US: PDF
-          zh_Hans: PDF
-          pt_BR: PDF
-          ja_JP: PDF
-        value: pdf
-      - label:
-          en_US: GitHub
-          zh_Hans: GitHub
-          pt_BR: GitHub
-          ja_JP: GitHub
-        value: github
-      - label:
-          en_US: Tweet
-          zh_Hans: 推文
-          pt_BR: Tuite
-          ja_JP: ツイート
-        value: tweet
-      - label:
           en_US: Personal Site
           zh_Hans: 个人网站
           pt_BR: Site Pessoal
           ja_JP: 個人サイト
         value: personal site
-      - label:
-          en_US: LinkedIn Profile
-          zh_Hans: LinkedIn 个人主页
-          pt_BR: Perfil do LinkedIn
-          ja_JP: LinkedInプロファイル
-        value: linkedin profile
       - label:
           en_US: Financial Report
           zh_Hans: 财务报告

--- a/tools/exa_similar.py
+++ b/tools/exa_similar.py
@@ -48,12 +48,9 @@ class ExaSimilarTool(Tool):
             # Make API request
             headers = {
                 "x-api-key": api_key,
-                "Content-Type": "application/json"
+                "Content-Type": "application/json",
+                "x-exa-integration": "dify-community-integration",
             }
-            
-            # Print request details for debugging
-            print(f"Request URL: https://api.exa.ai/findSimilar")
-            print(f"Request Payload: {json.dumps(payload)}")
             
             response = requests.post(
                 "https://api.exa.ai/findSimilar",


### PR DESCRIPTION
Updates all Exa tools to align with the current API:

**Search**
- Search types updated to `auto`, `fast`, `instant`, `deep` (removed `neural`/`keyword`)
- Categories limited to the current 6: company, people, research paper, news, personal site, financial report
- `use_autoprompt` hidden from UI (kept in code for backwards compat)

**Contents**
- Highlights enabled by default, text opt-in
- `maxAgeHours` replaces `livecrawl` (compat mapping: always→0, never→-1, fallback→24)
- `ai_page_summary` hidden from UI

**All tools**
- Added `x-exa-integration: dify-community-integration` header

**Docs**
- README cleaned up to reflect current tool set
- Removed references to answer and similar endpoints from docs